### PR TITLE
ENH: Add basic netcdf handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
                     },
                     {
                         "filenamePattern": "*.h5"
+                    },
+                    {
+                        "filenamePattern": "*.nc"
                     }
                 ],
                 "priority": "default"


### PR DESCRIPTION
Hi and thanks for this extension!

The extension seems to handle [netcdf4 files](https://www.earthdata.nasa.gov/esdis/esco/standards-and-practices/netcdf-4hdf5-file-format) pretty well (as far as I can see). However I have to manually change my file extensions from `.nc` to `.hdf`.

This PR makes it even more straightforward by recognizing ".nc" as valid file format for the extension.

---

Note: I have issues setting up the dev environment thus I can't really test this change unfortunately.